### PR TITLE
Update package.json

### DIFF
--- a/packages/plugin-triple-handle-controller/package.json
+++ b/packages/plugin-triple-handle-controller/package.json
@@ -1,8 +1,30 @@
 {
-  {
-  "license": "Apache-2.0"
-  }
-  "dependencies": {
+  "name": "@jspsych-contrib/plugin-triple-handle-controller",
+  "version": "1.0.0",
+  "description": "This plugin collects responses to a video file in real time using a game controller.",
+  "unpkg": "dist/index.browser.min.js",
+  "files": [
+    "index.js",
+    "dist"
+  ],
+  "scripts": {
+    "build": "babel index.js --presets @babel/preset-env,minify --source-maps --out-file dist/index.browser.min.js",
+    "build:watch": "npm run build -- --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jspsych/jspsych-contrib.git",
+    "directory": "packages/plugin-triple-handle-controller"
+  },
+  "contributors": ["Caluã de Lacerda Pataca", "Russell Lee"],
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/jspsych/jspsych-contrib/issues"
+  },
+  "homepage": "https://github.com/jspsych/jspsych-contrib/tree/main/packages/plugin-triple-handle-controller",
+  "devDependencies": {
+    "@jspsych/config": "^3.2.1",
+    "jspsych": "^8.1.0",
     "prettier": "^2.8.4"
   }
 }

--- a/packages/plugin-triple-handle-controller/src/index.js
+++ b/packages/plugin-triple-handle-controller/src/index.js
@@ -62,7 +62,8 @@ var jsTripleHandleController = (function (jspsych) {
           "Indices of the game controller axis that will control measurement axis 3.",
       },
       axis_location: {
-        type: jspsych.ParameterType.COMPLEX,
+        type: jspsych.ParameterType.STRING,
+        array: true,
         default: ["L", "H", "R"],
         description:
           "The location of the axes on the screen. L = left, H = hidden, R = right.",

--- a/packages/plugin-triple-handle-controller/src/index.js
+++ b/packages/plugin-triple-handle-controller/src/index.js
@@ -31,7 +31,7 @@ var jsTripleHandleController = (function (jspsych) {
   /* Set up constants */
   const info = {
     name: "3-axis video annotation",
-    version: "0.1.0",
+    version: "1.0.0",
     parameters: {
       title: {
         type: jspsych.ParameterType.STRING,


### PR DESCRIPTION
Updates package.json with more information. 

Closes caluap/jspsych-triple-handle-controller-plugin/issues/13.

Before this gets pulled in, does this plugin need `prettier` as a dependency, or can this be removed?